### PR TITLE
Update uuid dependency to the version 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "block-utils"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Chris Holcombe <xfactor973@gmail.com>"]
 description = "Utilities to work with block devices.  Formatting, getting device info, identifying type of device, etc."
 edition = '2018'
@@ -24,4 +24,4 @@ nom = "4"
 regex = "1"
 shellscript = "0.3"
 serde_json = "1"
-uuid = "0.7"
+uuid = "0.8"


### PR DESCRIPTION
The crate block-utils and the crates in assurio repository use different versions of
uuid. We should update it to the latest version (0.8) for avoiding duplicates of dependencies.